### PR TITLE
Does Nostr Protocol Use any ZK (Zero Knowledge) Tech ? -> No

### DIFF
--- a/nostr_research.md
+++ b/nostr_research.md
@@ -385,3 +385,57 @@ alternative to traditional social media platforms.
  community governance, which are crucial for maintaining a healthy digital ecosystem.
 - The adoption and impact of Nostr in the broader social media landscape will be an important area
  to monitor in the coming years.
+
+# In the cryptographic implementation of the Nostr Protocol, is there any application of zero-knowledge (ZK) technology specifically utilized for the purpose of enhancing message privacy?
+
+No, the Nostr protocol does not use zero-knowledge (ZK) technology for message privacy. Nostr, short for "Notes and Other Stuff Transmitted by Relays," is a decentralized and open protocol designed for creating censorship-resistant social networks. It primarily uses public/private key cryptography for identity and message verification, but it does not employ zero-knowledge proofs or similar technologies for message privacy.
+
+In the Nostr system, messages are signed by the user's private key and can be verified with their public key, ensuring authenticity and non-repudiation. However, since messages are typically stored on public relays and are not encrypted end-to-end, they do not have the same level of privacy that would be afforded by zero-knowledge techniques. The focus of Nostr is more on decentralization and resistance to censorship rather than on providing advanced privacy features like those offered by ZK technology.
+
+**Title: An Analysis of Nostr Protocol and Its Cryptographic Methods: Absence of Zero-Knowledge Technology in Ensuring Message Privacy**
+
+---
+
+### Abstract
+
+The Nostr protocol, an emergent framework for decentralized social networks, has gained attention for its approach to censorship resistance and digital identity verification. This paper provides a detailed analysis of the cryptographic methods employed by Nostr, focusing particularly on its approach to message privacy. Contrary to some contemporary protocols that leverage zero-knowledge (ZK) proofs for enhanced privacy, Nostr relies primarily on public/private key cryptography. This study aims to clarify the implications of this design choice, especially in the context of message confidentiality and user privacy.
+
+---
+
+### Introduction
+
+The decentralized nature of the internet has ushered in various protocols designed to enhance user freedom and privacy. Nostr, standing for "Notes and Other Stuff Transmitted by Relays," represents a significant stride in this direction. It is imperative to understand the cryptographic underpinnings of such protocols to evaluate their efficacy and application scope. This paper delves into the cryptographic landscape of Nostr, particularly its decision not to incorporate zero-knowledge proofs in its design.
+
+---
+
+### Methodology
+
+This study employed a qualitative analysis of the Nostr protocol, examining its official documentation, technical papers, and related cryptographic literature. By contrasting the Nostr framework with ZK technology-enabled protocols, the study highlights the differences in approaches to privacy and security.
+
+---
+
+### The Cryptographic Framework of Nostr
+
+Nostr implements public/private key cryptography for identity verification and message signing. Each user possesses a private key for signing messages and a public key for identity verification. This framework ensures the authenticity and non-repudiation of messages. However, it does not inherently provide privacy for message content, as messages are stored on public relays and are not encrypted end-to-end.
+
+---
+
+### The Absence of Zero-Knowledge Proofs in Nostr
+
+Zero-knowledge proofs allow one party to prove to another that a statement is true without conveying any additional information. This technology is pivotal in enhancing privacy in various cryptographic applications. Nostr’s design does not incorporate ZK proofs. This omission implies that while messages in Nostr are verifiable and resistant to censorship, they do not benefit from the enhanced privacy that ZK technology could offer.
+
+---
+
+### Implications and Future Directions
+
+The absence of ZK proofs in Nostr has significant implications for user privacy. Messages on Nostr, while authenticated, are accessible on public relays, making them less private than they could be with ZK technology. Future iterations of Nostr or similar protocols could explore integrating ZK proofs to strike a balance between censorship resistance, authenticity, and privacy.
+
+---
+
+### Conclusion
+
+Nostr represents a noteworthy development in decentralized social networks, emphasizing censorship resistance and authenticity. However, its cryptographic model does not incorporate zero-knowledge proofs, leading to potential limitations in message privacy. As the landscape of digital communication evolves, integrating advanced cryptographic techniques like ZK proofs could be vital in enhancing privacy and security in decentralized protocols.
+
+---
+
+**Keywords:** Nostr Protocol, Cryptography, Zero-Knowledge Proofs, Decentralization, Privacy, Public/Private Key Cryptography.


### PR DESCRIPTION
### In the cryptographic implementation of the Nostr Protocol, is there any application of zero-knowledge (ZK) technology specifically utilized for the purpose of enhancing message privacy?

- **No,** the Nostr protocol does not incorporate **zero-knowledge (ZK) technology** for message privacy. It uses public/private key cryptography primarily for identity verification and message authenticity, but not for advanced privacy features like those provided by ZK technology. Messages in Nostr are not end-to-end encrypted and are stored on public relays, focusing more on decentralization and censorship resistance rather than on enhanced privacy.